### PR TITLE
Show results even if build failed

### DIFF
--- a/BuildTimeAnalyzer/CMBuildOperation.swift
+++ b/BuildTimeAnalyzer/CMBuildOperation.swift
@@ -8,12 +8,18 @@
 
 import Foundation
 
+enum CMBuildResult : Int {
+    case Success = 1
+    case Failed = 2
+    case Cancelled = 3
+}
+
 struct CMBuildOperation {
     
     var actionName: String
     var productName: String
     var duration: Double
-    var result: Int
+    var result: CMBuildResult
     var startTime: NSDate
     
     var endTime: NSDate {

--- a/BuildTimeAnalyzer/CMLogProcessor.swift
+++ b/BuildTimeAnalyzer/CMLogProcessor.swift
@@ -128,11 +128,10 @@ class CMLogProcessor: NSObject, CMLogProcessorProtocol {
     }
     
     func processingDidFinish() {
-        timer?.invalidate()
-        timer = nil
-        
-        shouldCancel = false
         dispatch_async(dispatch_get_main_queue()) {
+            self.timer?.invalidate()
+            self.timer = nil
+            self.shouldCancel = false
             self.updateResults(true)
         }
     }

--- a/BuildTimeAnalyzer/CMResultWindowController.swift
+++ b/BuildTimeAnalyzer/CMResultWindowController.swift
@@ -135,14 +135,17 @@ class CMResultWindowController: NSWindowController {
         
         buildOperationDidGenerateOutputFilesObserver = NSNotificationCenter.addObserverForName(IDEBuildOperationDidGenerateOutputFilesNotification, usingBlock: { [weak self] (note) in
             guard let buildOperation = CMXcodeWorkSpace.buildOperation(fromData: note.object) else { return  }
+            let result = buildOperation.result
             
-            if buildOperation.result == 1 && buildOperation.actionName == "Build" {
-                self?.buildDurationTextField.stringValue = String(format: "%.0fs", round(buildOperation.duration))
-                self?.processLog(buildOperation.productName, buildCompletionDate: buildOperation.endTime)
-            } else {
+            guard buildOperation.actionName == "Build" && (result == .Success || result == .Failed || result == .Cancelled) else {
                 self?.processingState = .waiting(shouldIndicate: false)
+                return
             }
+            
+            self?.buildDurationTextField.stringValue = String(format: "%.0fs", round(buildOperation.duration))
+            self?.processLog(buildOperation.productName, buildCompletionDate: buildOperation.endTime)
         })
+        
     }
     
     func removeObservers() {

--- a/BuildTimeAnalyzer/CMXcodeWorkspace.swift
+++ b/BuildTimeAnalyzer/CMXcodeWorkspace.swift
@@ -73,11 +73,12 @@ extension CMXcodeWorkspaceProtocol {
         guard let actionName = data?.valueForKeyPath("_buildOperationDescription._actionName") as? String,
             let productName = data?.valueForKeyPath("_buildOperationDescription._objectToBuildName") as? String,
             let duration = data?.valueForKey("duration") as? Double,
-            let result = data?.valueForKey("_result") as? Int,
+            let intResult = data?.valueForKey("_result") as? Int,
+            let cmResult = CMBuildResult(rawValue: intResult),
             let startTime = data?.valueForKey("_startTime") as? NSDate else {
                 return nil
         }
-        return CMBuildOperation(actionName: actionName, productName: productName, duration: duration, result: result, startTime: startTime)
+        return CMBuildOperation(actionName: actionName, productName: productName, duration: duration, result: cmResult, startTime: startTime)
     }
     
     static func currentProductName() -> String? {


### PR DESCRIPTION
Here we're showing results even if build cancelled or failed.
Enum added to give more semantic to build results
Fix added, when timer was continiously running even after processing finished which caused empty table showing