### PR TITLE
Show cumulative compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+.DS_Store

--- a/BuildTimeAnalyzer/CMCompileMeasure.swift
+++ b/BuildTimeAnalyzer/CMCompileMeasure.swift
@@ -14,11 +14,15 @@ struct CMCompileMeasure {
     var path: String
     var code: String
     var filename: String
-    
+
     private var locationArray: [Int]
-    
+
+    var fileAndLine: String {
+        return "\(filename):\(locationArray[0])"
+    }
+
     var fileInfo: String {
-        return "\(filename):\(locationArray[0]):\(locationArray[1])"
+        return "\(fileAndLine):\(locationArray[1])"
     }
     
     var location: Int {

--- a/BuildTimeAnalyzer/CMLogProcessor.swift
+++ b/BuildTimeAnalyzer/CMLogProcessor.swift
@@ -62,7 +62,9 @@ extension CMLogProcessorProtocol {
                 let value = text.substringFromIndex(text.startIndex.advancedBy(match.range.length - 1))
                 unprocessedResult.append(CMRawMeasure(time: time, text: value))
             }
-            guard !shouldCancel else { break }
+            if shouldCancel {
+                break
+            }
         }
         processingDidFinish()
     }

--- a/BuildTimeAnalyzer/CMLogProcessor.swift
+++ b/BuildTimeAnalyzer/CMLogProcessor.swift
@@ -39,23 +39,20 @@ extension CMLogProcessorProtocol {
     // MARK: Private methods
     
     private func process(text text: String) {
-        let matchingOption = NSMatchingOptions(rawValue: 0)
-        let compareOptions = NSStringCompareOptions(rawValue: 0)
         let characterSet = NSCharacterSet(charactersInString:"\r\"")
-
         var remainingRange = text.startIndex..<text.endIndex
         
         unprocessedResult.removeAll()
         processingDidStart()
         
-        while let nextRange = text.rangeOfCharacterFromSet(characterSet, options: compareOptions, range: remainingRange) {
+        while let nextRange = text.rangeOfCharacterFromSet(characterSet, options: [], range: remainingRange) {
             let currentRange = remainingRange.startIndex..<nextRange.endIndex
             let text = text.substringWithRange(currentRange)
             
             defer { remainingRange = nextRange.endIndex..<remainingRange.endIndex }
             
             let range = NSMakeRange(0, text.characters.count)
-            guard let match = processRx.firstMatchInString(text, options: matchingOption, range: range) else { continue }
+            guard let match = processRx.firstMatchInString(text, options: [], range: range) else { continue }
             
             let timeString = text.substringToIndex(text.startIndex.advancedBy(match.range.length - 4))
             if let time = Double(timeString) {

--- a/BuildTimeAnalyzer/CMLogProcessor.swift
+++ b/BuildTimeAnalyzer/CMLogProcessor.swift
@@ -70,35 +70,25 @@ extension CMLogProcessorProtocol {
         }
 
         for (k, v) in rawMeasures {
-            unprocessedResult.append(CMRawMeasure(time: v, text: k))
+            // Only show files whose compile time is above 10ms
+            if v > 10 {
+                unprocessedResult.append(CMRawMeasure(time: v, text: k))
+            }
         }
+
+        unprocessedResult.sortInPlace{ $0.time > $1.time }
 
         processingDidFinish()
     }
     
     private func updateResults(didComplete: Bool) {
-        let cappedResult = capEntries(unprocessedResult)
-        updateHandler?(result: processResult(cappedResult), didComplete: didComplete)
-        
+        updateHandler?(result: processResult(unprocessedResult), didComplete: didComplete)
         if didComplete {
             unprocessedResult.removeAll()
         }
     }
-    
-    private func capEntries(entries: [CMRawMeasure]) -> [CMRawMeasure] {
-        let limit = 20
-        
-        let distinct = Array(Set(entries))
-        var sorted = distinct.sort{ $0.time > $1.time }
-        if sorted.count > limit {
-            sorted = Array(sorted[0..<limit])
-        }
-        return sorted
-    }
-    
+
     private func processResult(unprocessedResult: [CMRawMeasure]) -> [CMCompileMeasure] {
-        let unprocessedResult = capEntries(unprocessedResult)
-        
         var result: [CMCompileMeasure] = []
         for entry in unprocessedResult {
             let code = entry.text.characters.split("\t").map(String.init)

--- a/BuildTimeAnalyzer/CMLogProcessor.swift
+++ b/BuildTimeAnalyzer/CMLogProcessor.swift
@@ -18,6 +18,8 @@ protocol CMLogProcessorProtocol: class {
     func processingDidFinish()
 }
 
+private let processRx = try! NSRegularExpression(pattern:  "^\\d*\\.?\\dms\\t/", options: [])
+
 extension CMLogProcessorProtocol {
     func process(productName: String, buildCompletionDate: NSDate?, updateHandler: CMUpdateClosure?) {
         workspace = CMXcodeWorkSpace(productName: productName, buildCompletionDate: buildCompletionDate)
@@ -37,14 +39,10 @@ extension CMLogProcessorProtocol {
     // MARK: Private methods
     
     private func process(text text: String) {
-        let locationPattern = "^\\d*\\.?\\dms\\t/"
         let matchingOption = NSMatchingOptions(rawValue: 0)
         let compareOptions = NSStringCompareOptions(rawValue: 0)
-        let regexOptions = NSRegularExpressionOptions(rawValue: 0)
         let characterSet = NSCharacterSet(charactersInString:"\r\"")
-        
-        let regex = try! NSRegularExpression(pattern: locationPattern, options: regexOptions)
-        
+
         var remainingRange = text.startIndex..<text.endIndex
         
         unprocessedResult.removeAll()
@@ -57,7 +55,7 @@ extension CMLogProcessorProtocol {
             defer { remainingRange = nextRange.endIndex..<remainingRange.endIndex }
             
             let range = NSMakeRange(0, text.characters.count)
-            guard let match = regex.firstMatchInString(text, options: matchingOption, range: range) else { continue }
+            guard let match = processRx.firstMatchInString(text, options: matchingOption, range: range) else { continue }
             
             let timeString = text.substringToIndex(text.startIndex.advancedBy(match.range.length - 4))
             if let time = Double(timeString) {


### PR DESCRIPTION
This change groups all identical lines together and shows their summed up build time. It also removes the 20 results limit and only logs files whose cumulative compile time exceeds 10ms. Also if a single line in the same source file produces multiple results, but with a different column, they are summed up too.

This unfortunately also disables the live update (for now).

Closes #26 