### PR TITLE
Use NSString’s length instead of String.CharacterView.count, since we…

### DIFF
--- a/BuildTimeAnalyzer/LogProcessor.swift
+++ b/BuildTimeAnalyzer/LogProcessor.swift
@@ -47,7 +47,7 @@ extension LogProcessorProtocol {
                 remainingRange = nextRange.upperBound..<remainingRange.upperBound
             }
             
-            let range = NSMakeRange(0, text.characters.count)
+            let range = NSMakeRange(0, (text as NSString).length)
             guard let match = regex.firstMatch(in: text, options: [], range: range) else { continue }
             
             let timeString = text.substring(to: text.characters.index(text.startIndex, offsetBy: match.range.length - 4))


### PR DESCRIPTION
…’re going to use the range in an NSMakeRange call anyways

String.CharacterView's count is taking 40% of the time parsing the logs:

<img width="1123" alt="captura de tela 2017-03-30 as 19 00 27" src="https://cloud.githubusercontent.com/assets/6502879/24528534/5c5032c8-157d-11e7-9999-c0870f6fce6b.png">

Simply changing a line to use NSString's length property improves the performance by about 2x:

<img width="1125" alt="captura de tela 2017-03-30 as 19 14 58" src="https://cloud.githubusercontent.com/assets/6502879/24528563/7f5c9d6a-157d-11e7-8832-ae960b426cac.png">

There's still a lot of time being spent with rangeOfCharacters, seems to be related to retain/releases, but this is a good starting improvement!
