### PR TITLE
Add goto line script

### DIFF
--- a/BuildTimeAnalyzer/ViewController.swift
+++ b/BuildTimeAnalyzer/ViewController.swift
@@ -285,6 +285,23 @@ extension ViewController: NSTableViewDataSource {
         let item = filteredData?[row] ?? dataSource[row]
         NSWorkspace.shared().openFile(item.path)
         
+
+        let gotoLineScript =
+            "tell application \"Xcode\"\n" +
+            "  activate\n" +
+            "end tell\n" +
+            "tell application \"System Events\"\n" +
+            "  keystroke \"l\" using command down\n" +
+            "  keystroke \"\(item.location)\"\n" +
+            "  keystroke return\n" +
+            "end tell"
+
+        DispatchQueue.main.async {
+            if let script = NSAppleScript(source: gotoLineScript) {
+                script.executeAndReturnError(nil)
+            }
+        }
+        
         return true
     }
 }


### PR DESCRIPTION
Yesterday Martin Andonoski talked about improving Xcode build times at CocoaHeads Stockholm meetup. https://www.meetup.com/CocoaHeads-Stockholm/events/242804630/ 

Very interesting, tested the BuildTimeAnalyzer. I like it. Though it did not open the files at the line. So I added it here. I use the same method in the CodeSteps app I created. http://dyna.mo/bookmarking-tool-for-code/