### PR TITLE
Sorting by filename

### DIFF
--- a/BuildTimeAnalyzer.xcodeproj/project.pbxproj
+++ b/BuildTimeAnalyzer.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2839B8691FD2896F004C075C /* ViewControllerDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2839B8681FD2896F004C075C /* ViewControllerDataSource.swift */; };
+		2839B86B1FD32766004C075C /* ViewControllerDataSourceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2839B86A1FD32766004C075C /* ViewControllerDataSourceTest.swift */; };
 		2A3164C81D21D73F00064045 /* CompileMeasure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3164C01D21D73F00064045 /* CompileMeasure.swift */; };
 		2A3164C91D21D73F00064045 /* LogProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3164C11D21D73F00064045 /* LogProcessor.swift */; };
 		2A3164CB1D21D73F00064045 /* ProcessingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3164C31D21D73F00064045 /* ProcessingState.swift */; };
@@ -39,6 +41,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2839B8681FD2896F004C075C /* ViewControllerDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerDataSource.swift; sourceTree = "<group>"; };
+		2839B86A1FD32766004C075C /* ViewControllerDataSourceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerDataSourceTest.swift; sourceTree = "<group>"; };
 		2A3164C01D21D73F00064045 /* CompileMeasure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompileMeasure.swift; sourceTree = "<group>"; };
 		2A3164C11D21D73F00064045 /* LogProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogProcessor.swift; sourceTree = "<group>"; };
 		2A3164C31D21D73F00064045 /* ProcessingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessingState.swift; sourceTree = "<group>"; };
@@ -142,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				2A3698AB1D80A33B002C5CDA /* ViewController.swift */,
+				2839B8681FD2896F004C075C /* ViewControllerDataSource.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -196,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				2A3164CF1D21D74A00064045 /* CompileMeasureTests.swift */,
+				2839B86A1FD32766004C075C /* ViewControllerDataSourceTest.swift */,
 				2A3164D71D21D7A800064045 /* Supporting Files */,
 			);
 			path = BuildTimeAnalyzerTests;
@@ -306,6 +312,7 @@
 				2A9807DD1D7C71F900B9232C /* DirectoryMonitor.swift in Sources */,
 				2A3164DA1D21D90100064045 /* NSData+GZIP.m in Sources */,
 				2A3164C91D21D73F00064045 /* LogProcessor.swift in Sources */,
+				2839B8691FD2896F004C075C /* ViewControllerDataSource.swift in Sources */,
 				2A5404011D86D01700DBD44C /* BuildManager.swift in Sources */,
 				2A5404051D86F3C700DBD44C /* File.swift in Sources */,
 				2ABFB6CE1D81F2DE00D060BF /* NSAlert+Extensions.swift in Sources */,
@@ -327,6 +334,7 @@
 			files = (
 				2A3164D51D21D77500064045 /* NSData+GZIP.m in Sources */,
 				2A3164D01D21D74A00064045 /* CompileMeasureTests.swift in Sources */,
+				2839B86B1FD32766004C075C /* ViewControllerDataSourceTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BuildTimeAnalyzer/CompileMeasure.swift
+++ b/BuildTimeAnalyzer/CompileMeasure.swift
@@ -5,15 +5,20 @@
 
 import Foundation
 
-struct CompileMeasure {
+@objcMembers class CompileMeasure: NSObject {
     
-    var time: Double
+    dynamic var time: Double
     var path: String
     var code: String
-    var filename: String
+    dynamic var filename: String
     var references: Int
 
     private var locationArray: [Int]
+
+    public enum Order: String {
+        case filename
+        case time
+    }
 
     var fileAndLine: String {
         return "\(filename):\(locationArray[0])"

--- a/BuildTimeAnalyzer/Main.storyboard
+++ b/BuildTimeAnalyzer/Main.storyboard
@@ -527,7 +527,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zkv-Tf-sdq">
-                                        <rect key="frame" x="190" y="305" width="226" height="17"/>
+                                        <rect key="frame" x="190" y="305" width="225" height="17"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="2) Clean your project (⌘ + Shift + K)" id="eMR-lR-OuM">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -535,7 +535,7 @@ Gw
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PV7-TD-diE">
-                                        <rect key="frame" x="190" y="253" width="340" height="17"/>
+                                        <rect key="frame" x="190" y="253" width="339" height="17"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="3) Build your project (⌘ + B) and wait for it to complete" id="WcG-TO-qa4">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/BuildTimeAnalyzer/ViewControllerDataSource.swift
+++ b/BuildTimeAnalyzer/ViewControllerDataSource.swift
@@ -1,0 +1,90 @@
+//
+//  ViewControllerDataSource.swift
+//  BuildTimeAnalyzer
+//
+//  Created by Dmitrii on 02/12/2017.
+//  Copyright © 2017 Cane Media Ltd. All rights reserved.
+//
+
+import Foundation
+
+class ViewControllerDataSource {
+
+    var aggregateByFile = false {
+        didSet {
+            processData()
+        }
+    }
+
+    var filter = "" {
+        didSet {
+            processData()
+        }
+    }
+
+    var sortDescriptors = [NSSortDescriptor]() {
+        didSet {
+            processData()
+        }
+    }
+
+    fileprivate var originalData = [CompileMeasure]()
+    fileprivate var processedData = [CompileMeasure]()
+
+    func resetSourceData(newSourceData: [CompileMeasure]) {
+        originalData = newSourceData
+        processData()
+    }
+
+    func isEmpty() -> Bool {
+        return processedData.isEmpty
+    }
+
+    func count() -> Int {
+        return processedData.count
+    }
+
+    func measure(index: Int) -> CompileMeasure? {
+        guard index < processedData.count && index >= 0 else { return nil }
+        return processedData[index]
+    }
+
+    // MARK: - Private methods
+
+    private func processData() {
+        var newProcessedData = aggregateIfNeeded(originalData)
+        newProcessedData = applySortingIfNeeded(newProcessedData)
+        newProcessedData = applyFilteringIfNeeded(newProcessedData)
+
+        processedData = newProcessedData
+    }
+
+    private func aggregateIfNeeded(_ input: [CompileMeasure]) -> [CompileMeasure] {
+        guard aggregateByFile else { return input }
+        var fileTimes: [String: CompileMeasure] = [:]
+        for measure in input {
+            if let fileMeasure = fileTimes[measure.path] {
+                fileMeasure.time += measure.time
+                fileTimes[measure.path] = fileMeasure
+            } else {
+                let newFileMeasure = CompileMeasure(rawPath: measure.path, time: measure.time)
+                fileTimes[measure.path] = newFileMeasure
+            }
+        }
+        return Array(fileTimes.values)
+    }
+
+    private func applySortingIfNeeded(_ input: [CompileMeasure]) -> [CompileMeasure] {
+        if sortDescriptors.isEmpty { return input }
+        return (input as NSArray).sortedArray(using: sortDescriptors) as! Array
+    }
+
+    private func applyFilteringIfNeeded(_ input: [CompileMeasure]) -> [CompileMeasure] {
+        guard !filter.isEmpty else { return input }
+        return input.filter{ textContains($0.code, pattern: filter) || textContains($0.filename, pattern: filter) }
+    }
+
+    private func textContains(_ text: String, pattern: String) -> Bool {
+        return text.lowercased().contains(pattern.lowercased())
+    }
+}

--- a/BuildTimeAnalyzerTests/ViewControllerDataSourceTest.swift
+++ b/BuildTimeAnalyzerTests/ViewControllerDataSourceTest.swift
@@ -1,0 +1,188 @@
+//
+//  ViewControllerDataSourceTest.swift
+//  BuildTimeAnalyzerTests
+//
+//  Created by Dmitrii on 02/12/2017.
+//  Copyright © 2017 Cane Media Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import BuildTimeAnalyzer
+
+class ViewControllerDataSourceTest: XCTestCase {
+
+    var measArray: [CompileMeasure]!
+
+    override func setUp() {
+        super.setUp()
+        let meas1 = CompileMeasure(rawPath: "FileName1.swift:1:1", time: 10)
+        let meas2 = CompileMeasure(rawPath: "FileName2.swift:2:2", time: 2)
+        let meas3 = CompileMeasure(rawPath: "FileName3.swift:3:3", time: 8)
+        let meas4 = CompileMeasure(rawPath: "FileName3.swift:4:4", time: 0)
+        let meas5 = CompileMeasure(rawPath: "FileName1.swift:5:5", time: 2)
+        measArray = [meas4!, meas5!, meas2!, meas3!, meas1!]
+    }
+
+    func testInit() {
+        let dataSource = ViewControllerDataSource()
+
+        XCTAssertFalse(dataSource.aggregateByFile)
+        XCTAssertEqual(dataSource.filter, "")
+        XCTAssertNotNil(dataSource.sortDescriptors)
+        XCTAssertEqual(dataSource.sortDescriptors.count, 0)
+        XCTAssertTrue(dataSource.isEmpty())
+    }
+
+    func testAggregate() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        dataSource.aggregateByFile = true
+
+        XCTAssertEqual(dataSource.count(), 3)
+        XCTAssertFalse(dataSource.isEmpty())
+    }
+
+    func testFilter_1() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        dataSource.filter = "1"
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 2)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName1.swift")
+    }
+
+    func testFilter_2() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        dataSource.filter = "2"
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 1)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName2.swift")
+    }
+
+    func testFilter_noMatch() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        dataSource.filter = "noMatch"
+
+        XCTAssertTrue(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 0)
+    }
+
+    func testSortTimeAscending() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        let desc = NSSortDescriptor(key: "time", ascending: true)
+        dataSource.sortDescriptors = [desc]
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 5)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 2)!.filename, "FileName2.swift")
+        XCTAssertEqual(dataSource.measure(index: 3)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 4)!.filename, "FileName1.swift")
+    }
+
+    func testSortFilenameDescending() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        let desc = NSSortDescriptor(key: "filename", ascending: false)
+        dataSource.sortDescriptors = [desc]
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 5)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 2)!.filename, "FileName2.swift")
+        XCTAssertEqual(dataSource.measure(index: 3)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 4)!.filename, "FileName1.swift")
+    }
+
+    func testSortFilenameAscending_TimeAscending() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        let descFilename = NSSortDescriptor(key: "filename", ascending: true)
+        let descTime = NSSortDescriptor(key: "time", ascending: true)
+        dataSource.sortDescriptors = [descFilename, descTime]
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 5)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 0)!.time, 2)
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.time, 10)
+        XCTAssertEqual(dataSource.measure(index: 2)!.filename, "FileName2.swift")
+        XCTAssertEqual(dataSource.measure(index: 3)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 3)!.time, 0)
+        XCTAssertEqual(dataSource.measure(index: 4)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 4)!.time, 8)
+    }
+
+    func testSortTimeAscending_FilenameDescending() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        let descTime = NSSortDescriptor(key: "time", ascending: true)
+        let descFilename = NSSortDescriptor(key: "filename", ascending: false)
+        dataSource.sortDescriptors = [descTime, descFilename]
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 5)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 0)!.time, 0)
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName2.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.time, 2)
+        XCTAssertEqual(dataSource.measure(index: 2)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 2)!.time, 2)
+        XCTAssertEqual(dataSource.measure(index: 3)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 3)!.time, 8)
+        XCTAssertEqual(dataSource.measure(index: 4)!.filename, "FileName1.swift")
+        XCTAssertEqual(dataSource.measure(index: 4)!.time, 10)
+    }
+
+    func testSortTimeAscending_Filter3() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        let descTime = NSSortDescriptor(key: "time", ascending: true)
+        dataSource.sortDescriptors = [descTime]
+        dataSource.filter = "3"
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 2)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 0)!.time, 0)
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.time, 8)
+    }
+
+    func testFilter3_Aggregate() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        dataSource.filter = "3"
+        dataSource.aggregateByFile = true
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 1)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName3.swift")
+    }
+
+    func testSortFilenameDescending_FilterCanceled_Aggregate() {
+        let dataSource = ViewControllerDataSource()
+        dataSource.resetSourceData(newSourceData: measArray)
+        let descFilename = NSSortDescriptor(key: "filename", ascending: false)
+        dataSource.sortDescriptors = [descFilename]
+        dataSource.filter = "2"
+        dataSource.aggregateByFile = true
+        dataSource.filter = ""
+
+        XCTAssertFalse(dataSource.isEmpty())
+        XCTAssertEqual(dataSource.count(), 3)
+        XCTAssertEqual(dataSource.measure(index: 0)!.filename, "FileName3.swift")
+        XCTAssertEqual(dataSource.measure(index: 1)!.filename, "FileName2.swift")
+        XCTAssertEqual(dataSource.measure(index: 2)!.filename, "FileName1.swift")
+
+    }
+}


### PR DESCRIPTION
Not sure if you agree with all the changes, but I'll try to explane them.

The original idea was to add standard sorting by filename to the table. I found it might be quite convenient to work file by file.

There were already several variants of data source in the ViewController (dataSource, filteredData, perFunctionTimes, perFileTimes), so adding one more wasn't an option. So I decided to incapsulate all the processing over the data array to a separate class (ViewControllerDataSource), store only one original array of items and apply all the aggregating, filtering and sorting dynamically if necessary. In my opinion it makes code and the logic cleaner and easily lets extend processing functionality (other operations under the data array if necessary).

Unfortunately I had to convert CompileMeasure to an objC class for being able to easily apply an array of sort descriptors. I couldn't find easy and elegant way to apply several sorting functions to swift array without a lot of pain (didn't want to implement something like http://chris.eidhof.nl/post/sort-descriptors-in-swift/). I thought that inheriting the model from NSObject and double casting the array (to NSArray and back to swift array) is not such a big deal considering the ability to use good old sort descriptors (which are built in to NSTableView)

All the basic functionality of ViewControllerDataSource is covered with tests.