### PR TITLE
fix: deprecated usage of 'class' keyword

### DIFF
--- a/BuildTimeAnalyzer/BuildManager.swift
+++ b/BuildTimeAnalyzer/BuildManager.swift
@@ -5,7 +5,7 @@
 
 import Cocoa
 
-protocol BuildManagerDelegate: class {
+protocol BuildManagerDelegate: AnyObject {
     func derivedDataDidChange()
     func buildManager(_ buildManager: BuildManager, shouldParseLogWithDatabase database: XcodeDatabase)
 }

--- a/BuildTimeAnalyzer/DirectoryMonitor.swift
+++ b/BuildTimeAnalyzer/DirectoryMonitor.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-protocol DirectoryMonitorDelegate: class {
+protocol DirectoryMonitorDelegate: AnyObject {
     func directoryMonitorDidObserveChange(_ directoryMonitor: DirectoryMonitor, isDerivedData: Bool)
 }
 

--- a/BuildTimeAnalyzer/LogProcessor.swift
+++ b/BuildTimeAnalyzer/LogProcessor.swift
@@ -9,7 +9,7 @@ typealias CMUpdateClosure = (_ result: [CompileMeasure], _ didComplete: Bool, _ 
 
 fileprivate let regex = try! NSRegularExpression(pattern:  "^\\d*\\.?\\d*ms\\t/", options: [])
 
-protocol LogProcessorProtocol: class {
+protocol LogProcessorProtocol: AnyObject {
     var rawMeasures: [String: RawMeasure] { get set }
     var updateHandler: CMUpdateClosure? { get set }
     var shouldCancel: Bool { get set }

--- a/BuildTimeAnalyzer/ProjectSelection.swift
+++ b/BuildTimeAnalyzer/ProjectSelection.swift
@@ -5,7 +5,7 @@
 
 import Cocoa
 
-protocol ProjectSelectionDelegate: class {
+protocol ProjectSelectionDelegate: AnyObject {
     func didSelectProject(with database: XcodeDatabase)
 }
 


### PR DESCRIPTION
Just changed them to AnyObject as Xcode suggests according to Swift changes